### PR TITLE
quick fix for Review test date check

### DIFF
--- a/test/Models/Review.spec.js
+++ b/test/Models/Review.spec.js
@@ -74,7 +74,9 @@ describe('Attributes', () => {
       const month = today.getMonth() + 1;
       const day = today.getDate();
       expect(reviews[0].date).toBe(
-        `${year}-${month < 10 ? '0' + month : month}-${day}`
+        `${year}-${month < 10 ? '0' + month : month}-${
+          day < 10 ? '0' + day : day
+        }`
       );
     });
   });


### PR DESCRIPTION
Quick fix that changes how the Review Model test checks the date value to work now that the month has changed